### PR TITLE
Refactor configurable keys to use dynamic class names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /vendor/
 *.swp
 *.swo
+.idea

--- a/src/Configurables/AggressivePrefetching.php
+++ b/src/Configurables/AggressivePrefetching.php
@@ -14,7 +14,7 @@ final readonly class AggressivePrefetching implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.aggressive-prefetching.enabled', true);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**

--- a/src/Configurables/AutomaticallyEagerLoadRelationships.php
+++ b/src/Configurables/AutomaticallyEagerLoadRelationships.php
@@ -14,7 +14,7 @@ final readonly class AutomaticallyEagerLoadRelationships implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.automatically-eager-load-relationships.enabled', true);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**

--- a/src/Configurables/ForceScheme.php
+++ b/src/Configurables/ForceScheme.php
@@ -14,7 +14,7 @@ final readonly class ForceScheme implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.force-scheme.enabled', true);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**

--- a/src/Configurables/ImmutableDates.php
+++ b/src/Configurables/ImmutableDates.php
@@ -15,7 +15,7 @@ final readonly class ImmutableDates implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.immutable-dates.enabled', true);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**

--- a/src/Configurables/ProhibitDestructiveCommands.php
+++ b/src/Configurables/ProhibitDestructiveCommands.php
@@ -14,7 +14,7 @@ final readonly class ProhibitDestructiveCommands implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.prohibit-destructive-commands.enabled', true);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**

--- a/src/Configurables/ShouldBeStrict.php
+++ b/src/Configurables/ShouldBeStrict.php
@@ -14,7 +14,7 @@ final readonly class ShouldBeStrict implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.should-be-strict.enabled', true);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**

--- a/src/Configurables/Unguard.php
+++ b/src/Configurables/Unguard.php
@@ -14,7 +14,7 @@ final readonly class Unguard implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean('essentials.unguard.enabled', false);
+        return config()->boolean(sprintf('essentials.%s', self::class), false);
     }
 
     /**


### PR DESCRIPTION
Replaced hardcoded configuration keys with dynamically generated ones using `sprintf` and `self::class`. This improves maintainability and reduces the risk of errors when adding or modifying config options. Added `.idea` to `.gitignore` to exclude IDE-specific files.

It's just a suggestion for improvement — I believe that using the namespace in the configuration index could help with modern PHP development.

Essentials config example:
```php
<?php

return [
    NunoMaduro\Essentials\Configurables\Unguard::class => false
];
```