### PR TITLE
Write test for ForceSchema and Unguard

### DIFF
--- a/tests/Configurables/ForceSchemaTest.php
+++ b/tests/Configurables/ForceSchemaTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\URL;
+use NunoMaduro\Essentials\Configurables\ForceScheme;
+
+it('forces HTTPS scheme when enabled', function (): void {
+    config()->set('essentials.' . ForceScheme::class, true);
+
+    $forceScheme = new ForceScheme();
+
+    expect($forceScheme->enabled())->toBeTrue();
+
+    $forceScheme->configure();
+
+    $generated = URL::to('/example');
+
+    expect($generated)->toStartWith('https://');
+});

--- a/tests/Configurables/UnguardTest.php
+++ b/tests/Configurables/UnguardTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use NunoMaduro\Essentials\Configurables\Unguard;
+
+it('unguards all Eloquent models when enabled', function (): void {
+    config()->set('essentials.' . Unguard::class, true);
+
+    $unguard = new Unguard();
+
+    expect($unguard->enabled())->toBeTrue();
+
+    expect(Model::isUnguarded())->toBeFalse();
+
+    $unguard->configure();
+
+    expect(Model::isUnguarded())->toBeTrue();
+});


### PR DESCRIPTION
This PR adds tests for the ForceScheme and Unguard configurables in the Essentials package.

ForceScheme Test: Verifies that the ForceScheme configurable correctly forces the https scheme when enabled, ensuring that URLs generated by URL::to() start with https://.

Unguard Test: Tests the Unguard configurable to confirm that all Eloquent models are unguarded when the configurable is enabled, and ensures that the Model::unguard() method is called properly.