### PR TITLE
feat: Add Configuration for Setting a Default Password

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,14 @@
         }
     },
     "scripts": {
-        "refacto": "rector",
+        "refactor": "rector",
         "lint": "pint",
-        "test:refacto": "rector --dry-run",
+        "test:refactor": "rector --dry-run",
         "test:lint": "pint --test",
         "test:types": "phpstan analyse --ansi",
         "test:unit": "pest --colors=always --coverage --parallel",
         "test": [
-            "@test:refacto",
+            "@test:refactor",
             "@test:lint",
             "@test:types",
             "@test:unit"

--- a/src/Configurables/SetDefaultPassword.php
+++ b/src/Configurables/SetDefaultPassword.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace NunoMaduro\Essentials\Configurables;
+
+use Illuminate\Validation\Rules\Password;
+use NunoMaduro\Essentials\Contracts\Configurable;
+
+class SetDefaultPassword implements Configurable
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function enabled(): bool
+    {
+        return config()->boolean(sprintf('essentials.%s', self::class), false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configure(): void
+    {
+        Password::defaults(
+            fn (): ?Password => app()->isProduction()
+                ? $this->passwordDefaults()
+                : null
+        );
+    }
+
+    private function passwordDefaults(): Password
+    {
+        return Password::min(8)
+            // ->letters()
+            // ->mixedCase()
+            // ->numbers()
+            // ->symbols()
+            ->uncompromised();
+    }
+}

--- a/src/Configurables/SetDefaultPassword.php
+++ b/src/Configurables/SetDefaultPassword.php
@@ -12,7 +12,7 @@ class SetDefaultPassword implements Configurable
      */
     public function enabled(): bool
     {
-        return config()->boolean(sprintf('essentials.%s', self::class), false);
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
     }
 
     /**
@@ -20,20 +20,6 @@ class SetDefaultPassword implements Configurable
      */
     public function configure(): void
     {
-        Password::defaults(
-            fn (): ?Password => app()->isProduction()
-                ? $this->passwordDefaults()
-                : null
-        );
-    }
-
-    private function passwordDefaults(): Password
-    {
-        return Password::min(8)
-            // ->letters()
-            // ->mixedCase()
-            // ->numbers()
-            // ->symbols()
-            ->uncompromised();
+        Password::defaults(fn (): ?Password => app()->isProduction() ? Password::min(12)->max(255)->uncompromised() : null);
     }
 }

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -23,6 +23,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
         Configurables\ForceScheme::class,
         Configurables\ImmutableDates::class,
         Configurables\ProhibitDestructiveCommands::class,
+        Configurables\SetDefaultPassword::class,
         Configurables\ShouldBeStrict::class,
         Configurables\Unguard::class,
     ];


### PR DESCRIPTION
Hi,

Curious what your thoughts are on adding a configuration for setting a default password.

By default I set the config option to `false` as I think it is best classed as a opinionated option.

For now, I just commented out all but one of the options, but if you're up for a discussion it can be amended.

Considered adding tests but I figured the framework already tests these?