### PR TITLE
Refactor URL Scheme enforcement to use `forceHttps()` method

### DIFF
--- a/src/Configurables/ForceScheme.php
+++ b/src/Configurables/ForceScheme.php
@@ -22,6 +22,6 @@ final readonly class ForceScheme implements Configurable
      */
     public function configure(): void
     {
-        URL::forceScheme('https');
+        URL::forceHttps();
     }
 }


### PR DESCRIPTION
Replaced the `URL::forceScheme('https')` with the more concise and expressive `URL::forceHttps()` method in the `configure()` function to enforce HTTPS protocol site-wide.This change improves readability.