### PR TITLE
feat: Add essentials:composer command for adding composer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,40 @@ return [
 ];
 ```
 
+## Commands
+
+You can run the following command to publish opinionated configuration files for the specified tools:
+
+### Composer scripts
+
+Add the following scripts to your `composer.json` file:
+
+```json
+{
+    "refactor": "rector",
+    "lint": "pint",
+    "test:refactor": "rector --dry-run",
+    "test:lint": "pint --test",
+    "test:types": "phpstan analyse --ansi",
+    "test:unit": "pest --colors=always --coverage --parallel",
+    "test": [
+        "@test:refactor",
+        "@test:lint",
+        "@test:types",
+        "@test:unit"
+    ]
+}
+```
+
+```bash
+php artisan essentials:composer {--force} {--backup}
+```
+
+*Options:*
+- `--force` - Overwrites the existing configuration file without asking for confirmation.
+- `--backup` - Creates a backup of the existing configuration file.
+
+
 ## Roadmap
 
 - Better defaults before each test case

--- a/src/Commands/ConfigureComposerCommand.php
+++ b/src/Commands/ConfigureComposerCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Commands;
+
+use Illuminate\Console\Command;
+
+final class ConfigureComposerCommand extends Command
+{
+    protected $signature = 'essentials:composer
+        {--force : Force the operation to run without confirmation}
+        {--backup : Create a backup of existing composer.json}';
+
+    protected $description = 'This command will configure the composer scripts with a opinionated default.';
+
+    public function handle(): int
+    {
+        if (! $this->option('force') && ! $this->confirm('Are you sure you want to update your composer.json', true)) {
+            return 0;
+        }
+
+        $stub_path = __DIR__.'/../../stubs/composer.stub';
+        $destination_path = base_path('composer.json');
+
+        if (! file_exists($stub_path)) {
+            $this->error('Composer scripts stub file not found.');
+
+            return 1;
+        }
+
+        if (file_exists($destination_path) && $this->option('backup')) {
+            copy($destination_path, $destination_path.'.backup');
+            $this->info('Backup created at: '.$destination_path.'.backup');
+        }
+
+        if (! file_exists($destination_path)) {
+            $this->error('composer.json file not found.');
+
+            return 1;
+        }
+
+        $this->info('Adding composer scripts to your composer.json...');
+
+        $original_composer_content = file_get_contents($destination_path);
+
+        if ($original_composer_content === false) {
+            $this->error('Failed to read composer.json file.');
+
+            return 1;
+        }
+
+        $stub_content = file_get_contents($stub_path);
+
+        if ($stub_content === false) {
+            $this->error('Failed to read composer scripts stub file.');
+
+            return 1;
+        }
+
+        $composer_json = (array) json_decode($original_composer_content, true);
+        $composer_scripts = (array) json_decode($stub_content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->error('Failed to decode composer.json file.');
+
+            return 1;
+        }
+
+        $composer_json['scripts'] = array_merge((array) ($composer_json['scripts'] ?? []), $composer_scripts);
+
+        if (file_put_contents($destination_path, json_encode($composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) === false) {
+            $this->error('Failed to write to composer.json file.');
+
+            return 1;
+        }
+
+        $this->info('Composer scripts added successfully.');
+
+        return 0;
+    }
+}

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Essentials;
 
+use Illuminate\Console\Command;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use NunoMaduro\Essentials\Commands\ConfigureComposerCommand;
 use NunoMaduro\Essentials\Contracts\Configurable;
 
 /**
@@ -31,6 +33,15 @@ final class EssentialsServiceProvider extends BaseServiceProvider
     ];
 
     /**
+     * The list of commands.
+     *
+     * @var list<class-string<Command>>
+     */
+    private array $commands = [
+        ConfigureComposerCommand::class,
+    ];
+
+    /**
      * Bootstrap the application services.
      */
     public function boot(): void
@@ -39,5 +50,9 @@ final class EssentialsServiceProvider extends BaseServiceProvider
             ->map(fn (string $configurable) => $this->app->make($configurable))
             ->filter(fn (Configurable $configurable): bool => $configurable->enabled())
             ->each(fn (Configurable $configurable) => $configurable->configure());
+
+        if ($this->app->runningInConsole()) {
+            $this->commands($this->commands);
+        }
     }
 }

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -36,7 +36,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
      *
      * @var list<class-string<Command>>
      */
-    private array $commands = [
+    private array $commandsList = [
         Commands\ConfigureComposerCommand::class,
         Commands\EssentialsPintCommand::class,
         Commands\MakeActionCommand::class,
@@ -53,7 +53,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
             ->each(fn (Configurable $configurable) => $configurable->configure());
 
         if ($this->app->runningInConsole()) {
-            $this->commands($this->commands);
+            $this->commands($this->commandsList);
 
             $this->publishes([
                 __DIR__.'/../stubs' => $this->app->basePath('stubs'),

--- a/stubs/composer.stub
+++ b/stubs/composer.stub
@@ -1,0 +1,14 @@
+{
+    "refactor": "rector",
+    "lint": "pint",
+    "test:refactor": "rector --dry-run",
+    "test:lint": "pint --test",
+    "test:types": "phpstan analyse --ansi",
+    "test:unit": "pest --colors=always --coverage --parallel",
+    "test": [
+        "@test:refactor",
+        "@test:lint",
+        "@test:types",
+        "@test:unit"
+    ]
+}

--- a/tests/Commands/ConfigureComposerCommandTest.php
+++ b/tests/Commands/ConfigureComposerCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+beforeEach(function (): void {
+    $composer_json = json_decode(file_get_contents(base_path('composer.json')), true);
+    $composer_json['scripts'] = [];
+
+    file_put_contents(base_path('composer.json'), json_encode($composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    if (file_exists(base_path('composer.json.backup'))) {
+        unlink(base_path('composer.json.backup'));
+    }
+});
+
+afterEach(function (): void {
+    $composer_json = json_decode(file_get_contents(base_path('composer.json')), true);
+    $composer_json['scripts'] = [];
+
+    file_put_contents(base_path('composer.json'), json_encode($composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    if (file_exists(base_path('composer.json.backup'))) {
+        unlink(base_path('composer.json.backup'));
+    }
+});
+
+it('adds composer scripts to composer.json', function (): void {
+    $this->artisan('essentials:composer', ['--force' => true])
+        ->assertExitCode(0)
+        ->assertSuccessful();
+
+    $composerJson = json_decode(file_get_contents(base_path('composer.json')), true);
+
+    expect($composerJson)->toHaveKey('scripts')
+        ->and($composerJson['scripts'])->toHaveKey('refactor')
+        ->and($composerJson['scripts'])->toHaveKey('lint')
+        ->and($composerJson['scripts'])->toHaveKey('test:refactor')
+        ->and($composerJson['scripts'])->toHaveKey('test:lint')
+        ->and($composerJson['scripts'])->toHaveKey('test:types')
+        ->and($composerJson['scripts'])->toHaveKey('test:unit')
+        ->and($composerJson['scripts'])->toHaveKey('test');
+});
+
+it('creates a backup when backup option is provided', function (): void {
+    $this->artisan('essentials:composer', ['--force' => true, '--backup' => true])
+        ->assertExitCode(0)
+        ->assertSuccessful();
+
+    expect(file_exists(base_path('composer.json.backup')))->toBeTrue();
+});
+
+it('does not create a backup when backup option is not provided', function (): void {
+    $this->artisan('essentials:composer', ['--force' => true])
+        ->assertExitCode(0)
+        ->assertSuccessful();
+
+    expect(file_exists(base_path('composer.json.backup')))->toBeFalse();
+});
+
+it('returns early when not confirmed', function (): void {
+    $this->artisan('essentials:composer')
+        ->expectsConfirmation('Are you sure you want to update your composer.json', 'no')
+        ->assertExitCode(0);
+
+    $originalContent = json_decode(file_get_contents(base_path('composer.json')), true);
+    expect($originalContent['scripts'])->not->toHaveKey('refactor');
+});


### PR DESCRIPTION
Introduced a new console command `essentials:composer` to automate the addition of opinionated composer scripts. The command includes options for confirmation and backup creation, along with associated tests and a stub file for default scripts.