### PR TITLE
Add default "Action" suffix to generated action class names when missing

### DIFF
--- a/src/Commands/MakeActionCommand.php
+++ b/src/Commands/MakeActionCommand.php
@@ -48,6 +48,26 @@ final class MakeActionCommand extends GeneratorCommand
     }
 
     /**
+     * Get the name input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        $name = trim($this->argument('name'));
+
+        if (Str::endsWith($name, '.php')) {
+            return Str::substr($name, 0, -4);
+        }
+
+        if(! Str::endsWith($name, 'Action')) {
+            return $name.'Action';
+        }
+
+        return $name;
+    }
+
+    /**
      * Get the stub file for the generator.
      */
     protected function getStub(): string

--- a/src/Commands/MakeActionCommand.php
+++ b/src/Commands/MakeActionCommand.php
@@ -39,7 +39,7 @@ final class MakeActionCommand extends GeneratorCommand
     {
         // First check if the class already exists
         if ($this->alreadyExists($this->getNameInput())) {
-            $this->error($this->type.' already exists!');
+            $this->error($this->type . ' already exists!');
 
             return 1;
         }
@@ -60,7 +60,7 @@ final class MakeActionCommand extends GeneratorCommand
             return Str::substr($name, 0, -4);
         }
 
-        if(! Str::endsWith($name, 'Action')) {
+        if (! Str::endsWith($name, 'Action')) {
             return $name.'Action';
         }
 

--- a/src/Commands/MakeActionCommand.php
+++ b/src/Commands/MakeActionCommand.php
@@ -52,7 +52,7 @@ final class MakeActionCommand extends GeneratorCommand
      *
      * @return string
      */
-    protected function getNameInput()
+    protected function getNameInput(): string
     {
         $name = trim($this->argument('name'));
 

--- a/tests/Commands/MakeActionCommandTest.php
+++ b/tests/Commands/MakeActionCommandTest.php
@@ -37,3 +37,20 @@ it('fails when the action already exists', function (): void {
 
     expect($exitCode)->toBe(1);
 });
+
+it('add suffix "Action" to action name if not provided', function (): void {
+    $actionName = 'CreateUser';
+    $exitCode = Artisan::call('make:action', ['name' => $actionName]);
+
+    expect($exitCode)->toBe(0);
+
+    $expectedPath = app_path('Actions/'.$actionName.'Action.php');
+    expect(File::exists($expectedPath))->toBeTrue();
+
+    $content = File::get($expectedPath);
+
+    expect($content)
+        ->toContain('namespace App\Actions;')
+        ->toContain('class '.$actionName.'Action')
+        ->toContain('public function handle(): void');
+});


### PR DESCRIPTION
This PR introduces logic to automatically append the "Action" suffix to action class names when not explicitly provided by the user.