### PR TITLE
feat: add EssentialsRectorCommand to publish Rector configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,25 @@ php artisan essentials:pint {--force} {--backup}
 - `--force` - Overwrites the existing configuration file without asking for confirmation.
 - `--backup` - Creates a backup of the existing configuration file.
 
+#### `essentials:rector`
+
+Rector is a powerful tool for refactoring and improving your codebase. This command will publish a configuration file for Rector that includes the following:
+
+- "deadCode" - Removes dead code from your codebase.
+- "codeQuality" - Improves code quality by applying best practices.
+- "typeDeclarations" - Adds type declarations to your codebase.
+- "privatization" - Privatizes class properties and methods where possible.
+- "earlyReturn" - Enforces early return statements in your codebase.
+- "strictBooleans" - Enforces strict boolean checks in your codebase.
+
+```bash
+php artisan essentials:rector {--force} {--backup}
+```
+
+*Options:*
+- `--force` - Overwrites the existing configuration file without asking for confirmation.
+- `--backup` - Creates a backup of the existing configuration file.
+
 
 ## Configuration
 

--- a/src/Commands/EssentialsRectorCommand.php
+++ b/src/Commands/EssentialsRectorCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Commands;
+
+use Illuminate\Console\Command;
+
+final class EssentialsRectorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'essentials:rector
+        {--force : Force the operation to run without confirmation}
+        {--backup : Create a backup of existing pint.json}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will publish an opinionated Rector configuration file for your project.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if (! $this->option('force') && ! $this->components->confirm('Do you wish to publish the Rector configuration file? This will override the existing [rector.php] file.', true)) {
+            return 0;
+        }
+
+        $stub_path = __DIR__.'/../../stubs/rector.stub';
+        $destination_path = base_path('rector.php');
+
+        if (! file_exists($stub_path)) {
+            $this->components->error('Rector configuration stub file not found.');
+
+            return 1;
+        }
+
+        if (file_exists($destination_path) && $this->option('backup')) {
+            copy($destination_path, $destination_path.'.backup');
+            $this->components->info('Backup created at: '.$destination_path.'.backup');
+        }
+
+        $this->components->info('Publishing Rector configuration file...');
+
+        if (! copy($stub_path, $destination_path)) {
+            $this->components->error('Failed to publish the Rector configuration file.');
+
+            return 1;
+        }
+
+        $this->components->info('Rector configuration file published successfully at: '.$destination_path);
+
+        return 0;
+    }
+}

--- a/src/Commands/EssentialsRectorCommand.php
+++ b/src/Commands/EssentialsRectorCommand.php
@@ -15,7 +15,7 @@ final class EssentialsRectorCommand extends Command
      */
     protected $signature = 'essentials:rector
         {--force : Force the operation to run without confirmation}
-        {--backup : Create a backup of existing pint.json}';
+        {--backup : Create a backup of existing rector.php}';
 
     /**
      * The console command description.

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Essentials;
 
+use Illuminate\Console\Command;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
-use NunoMaduro\Essentials\Commands\EssentialsPintCommand;
-use NunoMaduro\Essentials\Commands\MakeActionCommand;
 use NunoMaduro\Essentials\Contracts\Configurable;
 
 /**
@@ -42,7 +41,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
         Commands\EssentialsPintCommand::class,
         Commands\MakeActionCommand::class,
     ];
-    
+
     /**
      * Bootstrap the application services.
      */

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -33,6 +33,17 @@ final class EssentialsServiceProvider extends BaseServiceProvider
     ];
 
     /**
+     * The list of commands.
+     *
+     * @var list<class-string<Command>>
+     */
+    private array $commandsList = [
+        Commands\EssentialsRectorCommand::class,
+        Commands\EssentialsPintCommand::class,
+        Commands\MakeActionCommand::class,
+    ];
+    
+    /**
      * Bootstrap the application services.
      */
     public function boot(): void
@@ -43,11 +54,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
             ->each(fn (Configurable $configurable) => $configurable->configure());
 
         if ($this->app->runningInConsole()) {
-            $this->commands([
-                EssentialsPintCommand::class,
-                MakeActionCommand::class,
-                Commands\EssentialsRectorCommand::class,
-            ]);
+            $this->commands($this->commandsList);
 
             $this->publishes([
                 __DIR__.'/../stubs' => $this->app->basePath('stubs'),

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -46,6 +46,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
             $this->commands([
                 EssentialsPintCommand::class,
                 MakeActionCommand::class,
+                Commands\EssentialsRectorCommand::class,
             ]);
 
             $this->publishes([

--- a/stubs/rector.stub
+++ b/stubs/rector.stub
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/app',
+        __DIR__.'/bootstrap/app.php',
+        __DIR__.'/database',
+        __DIR__.'/public',
+    ])
+    ->withSkip([
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+    ])
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        privatization: true,
+        earlyReturn: true,
+        strictBooleans: true,
+    )
+    ->withPhpSets();

--- a/tests/Commands/EssentialsRectorCommandTest.php
+++ b/tests/Commands/EssentialsRectorCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use NunoMaduro\Essentials\Commands\EssentialsRectorCommand;
+
+beforeEach(function (): void {
+    if (file_exists(base_path('rector.php'))) {
+        unlink(base_path('rector.php'));
+    }
+
+    if (file_exists(base_path('rector.php.backup'))) {
+        unlink(base_path('rector.php.backup'));
+    }
+});
+
+it('publishes rector configuration file', function (): void {
+    $command = new EssentialsRectorCommand();
+
+    $this->artisan('essentials:rector', ['--force' => true])
+        ->assertExitCode(0);
+
+    expect(file_exists(base_path('rector.php')))->toBeTrue();
+});
+
+it('creates a backup when requested', function (): void {
+    File::put(base_path('rector.php'), '<?php return [];');
+
+    $this->artisan('essentials:rector', ['--backup' => true, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(file_exists(base_path('rector.php.backup')))->toBeTrue();
+});
+
+it('warns when file exists and no force option', function (): void {
+    File::put(base_path('rector.php'), '<?php return [];');
+
+    $this->artisan('essentials:rector')
+        ->expectsConfirmation('Do you wish to publish the Rector configuration file? This will override the existing [rector.php] file.', 'no')
+        ->assertExitCode(0);
+
+    expect(file_get_contents(base_path('rector.php')))->toBe('<?php return [];');
+});
+
+afterEach(function (): void {
+    if (file_exists(base_path('rector.php'))) {
+        unlink(base_path('rector.php'));
+    }
+
+    if (file_exists(base_path('rector.php.backup'))) {
+        unlink(base_path('rector.php.backup'));
+    }
+});


### PR DESCRIPTION
Just like the `essentials:pint` command, this publishes a rector.php config file based on a stub stored in the package.