### PR TITLE
feat: add command to configure essential Pest defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ php artisan essentials:pint {--force} {--backup}
 - `--force` - Overwrites the existing configuration file without asking for confirmation.
 - `--backup` - Creates a backup of the existing configuration file.
 
+#### `essentials:pest`
+
+Adds opinionated defaults to your Pest configuration. The command ensures your tests are more reliable and predictable by:
+
+- Preventing stray HTTP requests
+- Normalizing string and UUID generation
+- Faking sleep operations
+- Freezing time during tests
+- Configuring test paths for Feature and Unit tests
+
+```bash
+php artisan essentials:pest
+```
 
 ## Configuration
 

--- a/src/Commands/EssentialsPestCommand.php
+++ b/src/Commands/EssentialsPestCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class EssentialsPestCommand extends Command
+{
+    private const string OPENING_TAG = 'added with Essentials Script';
+
+    private const string CLOSING_TAG = 'end: '.self::OPENING_TAG;
+
+    protected $signature = 'essentials:pest';
+
+    protected $description = 'Add essential Pest configuration to your tests';
+
+    public function handle(): int
+    {
+        $pestFile = base_path('tests/Pest.php');
+
+        if (! File::exists($pestFile)) {
+            $this->error('🐞 Show some love to Pest! For Nuno\'s sake, install it first! 🚀');
+            $this->line('Run: <fg=gray>composer require pestphp/pest --dev && php artisan pest:install</>');
+
+            return Command::FAILURE;
+        }
+
+        $content = File::get($pestFile);
+
+        if (str_contains($content, self::OPENING_TAG)) {
+            $this->info('Essential Pest configuration already added.');
+
+            return Command::INVALID;
+        }
+
+        $stubPath = $this->getStub();
+
+        $stubContent = File::get($stubPath);
+
+        $newConfig = PHP_EOL.'// '.self::OPENING_TAG.PHP_EOL;
+        $newConfig .= $stubContent;
+        $newConfig .= PHP_EOL.'// '.self::CLOSING_TAG.PHP_EOL;
+
+        File::append($pestFile, $newConfig);
+
+        $this->info('Essential Pest configuration added successfully.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Get the stub file for the generator.
+     */
+    private function getStub(): string
+    {
+        return $this->resolveStubPath('/stubs/pest.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     */
+    private function resolveStubPath(string $stub): string
+    {
+        $basePath = base_path(ltrim($stub, '/'));
+
+        return File::exists($basePath)
+            ? $basePath
+            : __DIR__.'/../../'.$stub;
+    }
+}

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Essentials;
 
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use NunoMaduro\Essentials\Commands\EssentialsPestCommand;
 use NunoMaduro\Essentials\Commands\EssentialsPintCommand;
 use NunoMaduro\Essentials\Commands\MakeActionCommand;
 use NunoMaduro\Essentials\Contracts\Configurable;
@@ -44,6 +45,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->commands([
+                EssentialsPestCommand::class,
                 EssentialsPintCommand::class,
                 MakeActionCommand::class,
             ]);

--- a/stubs/pest.stub
+++ b/stubs/pest.stub
@@ -1,0 +1,28 @@
+/*
+|--------------------------------------------------------------------------
+| Essentials
+|--------------------------------------------------------------------------
+|
+| This configuration enhances your test suite with reliability features that
+| prevent common testing issues. By controlling randomness, time, and external
+| connections, these settings ensure your tests run consistently and predictably
+| across environments, preventing flaky tests and improving debugging efficiency.
+|
+| These defaults make tests faster, more isolated, and more deterministic without
+| requiring manual configuration for each test case in your application.
+|
+*/
+
+use Illuminate\Support\Sleep;
+
+pest()->extend(Tests\TestCase::class)
+    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->beforeEach(function () {
+        Str::createRandomStringsNormally();
+        Str::createUuidsNormally();
+        Http::preventStrayRequests();
+        Sleep::fake();
+
+        $this->freezeTime();
+    })
+    ->in('Feature', 'Unit');

--- a/stubs/pest.stub
+++ b/stubs/pest.stub
@@ -17,7 +17,7 @@ use Illuminate\Support\Sleep;
 
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->beforeEach(function () {
+    ->beforeEach(function (): void {
         Str::createRandomStringsNormally();
         Str::createUuidsNormally();
         Http::preventStrayRequests();

--- a/tests/Commands/EssentialsPestCommandTest.php
+++ b/tests/Commands/EssentialsPestCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+
+$cleanup = function (): void {
+    $pestFile = base_path('tests/Pest.php');
+    if (File::exists($pestFile)) {
+        File::delete($pestFile);
+    }
+
+    $stubsPath = base_path('stubs');
+    if (File::exists($stubsPath)) {
+        File::deleteDirectory($stubsPath);
+    }
+};
+
+beforeEach(fn () => $cleanup());
+afterEach(fn () => $cleanup());
+
+function createBasePestFile(): void
+{
+    $pestFile = base_path('tests/Pest.php');
+    $stubContent = File::get(__DIR__.'/../stubs/pest-base.stub');
+    File::put($pestFile, $stubContent);
+}
+
+it('adds essential pest configuration when Pest.php exists', function (): void {
+    createBasePestFile();
+    $pestFile = base_path('tests/Pest.php');
+
+    $this->artisan('essentials:pest')
+        ->assertSuccessful();
+
+    $content = File::get($pestFile);
+    expect($content)
+        ->toContain('// added with Essentials Script')
+        ->toContain('Http::preventStrayRequests()')
+        ->toContain('Sleep::fake()')
+        ->toContain('->in(\'Feature\', \'Unit\')');
+});
+
+it('skips adding configuration if already present', function (): void {
+    $pestFile = base_path('tests/Pest.php');
+    File::put($pestFile, "<?php\n\n// added with Essentials Script\n// some content");
+
+    $this->artisan('essentials:pest')
+        ->assertFailed()
+        ->expectsOutput('Essential Pest configuration already added.');
+});
+
+it('shows a friendly error when Pest.php does not exist', function (): void {
+    $this->artisan('essentials:pest')
+        ->assertFailed()
+        ->expectsOutput('🐞 Show some love to Pest! For Nuno\'s sake, install it first! 🚀');
+});
+
+it('uses published stub when available', function (): void {
+    createBasePestFile();
+    $pestFile = base_path('tests/Pest.php');
+
+    $this->artisan('vendor:publish', ['--tag' => 'essentials-stubs'])
+        ->assertSuccessful();
+
+    $publishedStubPath = base_path('stubs/pest.stub');
+    File::put($publishedStubPath, "// This is a custom stub\npest()->extend(Tests\TestCase::class)");
+
+    $this->artisan('essentials:pest')
+        ->assertSuccessful();
+
+    $content = File::get($pestFile);
+    expect($content)
+        ->toContain('// added with Essentials Script')
+        ->toContain('// This is a custom stub')
+        ->not->toContain('Sleep::fake()');
+});

--- a/tests/stubs/pest-base.stub
+++ b/tests/stubs/pest-base.stub
@@ -1,0 +1,47 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "pest()" function to bind a different classes or traits.
+|
+*/
+
+pest()->extend(Tests\TestCase::class)
+ // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}


### PR DESCRIPTION
## Overview
This PR introduces a new `essentials:pest` command that adds opinionated defaults to your Pest configuration. The command ensures your tests are more reliable and predictable by:

- Preventing stray HTTP requests
- Normalizing string and UUID generation
- Faking sleep operations
- Freezing time during tests
- Configuring test paths for Feature and Unit tests

## Credit & Inspiration
This feature was inspired by Nuno's livestream where he mentioned wanting to see such a command implemented. The configuration approach is based on his example in the [vest-kits/laravel](https://github.com/vest-kits/laravel/blob/main/tests/Pest.php) repository, which demonstrates these testing best practices in action.

## Technical Note
Initially, I explored using PHP-Parser to modify the Pest configuration file programmatically. However, this approach proved challenging due to:
- Complex AST transformations required
- Difficulty preserving original code formatting and comments
- Edge cases with different file structures

Instead, I opted for a simpler and more reliable approach of appending the configuration with clear section markers. While this might not be as sophisticated as AST manipulation, it's more maintainable and less prone to errors.

If you have a different vision for how this should be implemented, this PR can serve as a foundation for discussion and future improvements.
