### PR TITLE
fix: failing CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,9 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+        composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+        composer require --dev "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction 
 
     - name: Integration Tests
       run: php ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,12 @@ jobs:
         laravel: [11.44.2, '12.8.1']
         dependency-version: [prefer-lowest, prefer-stable]
 
+        include:
+         - laravel: 12.8.1
+           testbench: 10.*
+         - laravel: 11.44.2
+           testbench: 9.*
+           
     name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
@@ -39,19 +45,10 @@ jobs:
         key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
         restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
 
-    - name: Install Composer dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
-
-    - name: Require Testbench v9 for Laravel 11
-      if: startsWith(matrix.laravel, '11')
-      run: composer require --dev orchestra/testbench:^9.0 --no-interaction --with-all-dependencies
-
-    - name: Require Testbench v10 for Laravel 12
-      if: startsWith(matrix.laravel, '12')
-      run: composer require --dev orchestra/testbench:^10.0 --no-interaction --with-all-dependencies
-
-    - name: Install Laravel
-      run: composer require laravel/framework:${{ matrix.laravel }} --with-all-dependencies --no-interaction --prefer-dist
+    - name: Install dependencies
+      run: |
+        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
     - name: Integration Tests
       run: php ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
         php: ['8.3', '8.4']
         laravel: [11.44.2, '12.8.1']
         dependency-version: [prefer-lowest, prefer-stable]
-
         include:
          - laravel: 12.8.1
            testbench: 10.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
         restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
 
-    - name: Install dependencies
+    - name: Install Composer dependencies
       run: |
         composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction


### PR DESCRIPTION
Thanks for the cool repo 😎 

I noticed [CI was failing](https://github.com/nunomaduro/essentials/actions/runs/14671892541) and may cause confusion for people making prs etc etc..

For now I've fixed the issue and made some slight improvements to the dependencies install rather than breaking it into 3 steps we can do it in 1!

There's probably more improvements that can be made, but for now, this is the basics. 

[See the tests working here](https://github.com/jackbayliss/essentials/actions/runs/14686647033)