### PR TITLE
shouldBeStrict only in local

### DIFF
--- a/src/Configurables/ShouldBeStrict.php
+++ b/src/Configurables/ShouldBeStrict.php
@@ -22,6 +22,6 @@ final readonly class ShouldBeStrict implements Configurable
      */
     public function configure(): void
     {
-        Model::shouldBeStrict();
+        Model::shouldBeStrict(app()->isLocal());
     }
 }


### PR DESCRIPTION
To prevent errors in production, set `Model::shouldBeStrict()` to local environment only.

I think you mentioned this should be default on stream?

I chose local because I think testing and staging should pass regardless to simulate production. We just need the errors on our local end to catch them before they head up-stream. If we try to check testing/staging/etc then we end up over-complicating it.