### PR TITLE
Add `essentials:phpstan` command to publish PHPStan configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ All features are optional and configurable in `config/essentials.php`.
   - [make:action](#makeaction)
   - [essentials:pint](#essentialspint)
   - [essentials:rector](#essentialsrector)
+  - [essentials:phpstan](#essentialsphpstan)
 
 ### ✅ Strict Models
 
@@ -193,6 +194,21 @@ php artisan essentials:rector {--force} {--backup}
 - `--force` - Overwrites the existing configuration file without asking for confirmation.
 - `--backup` - Creates a backup of the existing configuration file.
 
+#### `essentials:phpstan`
+
+[PHPStan](https://phpstan.org/) is a powerful static analysis tool for modern PHP. This command will publish an opinionated configuration file for PHPStan that includes the following:
+
+- Maximum analysis level (`level: max`)
+- Includes common Laravel directories: `app`, `config`, `database`, `routes`, `tests`
+- Sensible defaults for Laravel projects
+
+```bash
+php artisan essentials:phpstan {--force} {--backup}
+```
+
+*Options:*
+- `--force` - Overwrites the existing configuration file without asking for confirmation.
+- `--backup` - Creates a backup of the existing configuration file.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ php artisan essentials:rector {--force} {--backup}
 
 - Maximum analysis level (`level: max`)
 - Includes common Laravel directories: `app`, `config`, `database`, `routes`, `tests`
-- Sensible defaults for Laravel projects
+- Sensible defaults for Laravel projects with [nunomaduro/larastan](https://github.com/nunomaduro/larastan)
 
 ```bash
 php artisan essentials:phpstan {--force} {--backup}

--- a/src/Commands/EssentialsPhpstanCommand.php
+++ b/src/Commands/EssentialsPhpstanCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+
+final class EssentialsPhpstanCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'essentials:phpstan
+        {--force : Force the operation to run without confirmation}
+        {--backup : Create a backup of existing phpstan.neon}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will publish an opinionated PHPStan configuration file for your project.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if (! $this->option('force') && ! $this->components->confirm('Do you wish to publish the PHPStan configuration file? This will override the existing [phpstan.neon] file.', true)) {
+            return 0;
+        }
+
+        // Check if larastan is installed
+        if (! $this->isLarastanInstalled()) {
+            $this->components->info('Installing nunomaduro/larastan...');
+
+            $result = Process::run('composer require nunomaduro/larastan --dev');
+
+            if (! $result->successful()) {
+                $this->components->error('Failed to install nunomaduro/larastan.');
+                $this->components->error($result->errorOutput());
+
+                return 1;
+            }
+
+            $this->components->info('nunomaduro/larastan installed successfully.');
+        }
+
+        $stub_path = __DIR__.'/../../stubs/phpstan.stub';
+        $destination_path = base_path('phpstan.neon');
+
+        if (! file_exists($stub_path)) {
+            $this->components->error('PHPStan configuration stub file not found.');
+
+            return 1;
+        }
+
+        if (file_exists($destination_path) && $this->option('backup')) {
+            copy($destination_path, $destination_path.'.backup');
+            $this->components->info('Backup created at: '.$destination_path.'.backup');
+        }
+
+        $this->components->info('Publishing PHPStan configuration file...');
+
+        if (! copy($stub_path, $destination_path)) {
+            $this->components->error('Failed to publish the PHPStan configuration file.');
+
+            return 1;
+        }
+
+        $this->components->info('PHPStan configuration file published successfully at: '.$destination_path);
+
+        return 0;
+    }
+
+    /**
+     * Check if nunomaduro/larastan is installed.
+     *
+     * @phpstan-return bool
+     */
+    private function isLarastanInstalled(): bool
+    {
+        $composerJsonPath = base_path('composer.json');
+        if (! file_exists($composerJsonPath)) {
+            return false;
+        }
+        $jsonString = file_get_contents($composerJsonPath);
+        if ($jsonString === false) {
+            return false;
+        }
+        /** @var array{require?: array<string, string>, require-dev?: array<string, string>} $composerJson */
+        $composerJson = json_decode($jsonString, true);
+
+        return isset($composerJson['require-dev']['nunomaduro/larastan'])
+            || isset($composerJson['require']['nunomaduro/larastan']);
+    }
+}

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -40,6 +40,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
         Commands\EssentialsRectorCommand::class,
         Commands\EssentialsPintCommand::class,
         Commands\MakeActionCommand::class,
+        Commands\EssentialsPhpstanCommand::class,
     ];
 
     /**

--- a/stubs/phpstan.stub
+++ b/stubs/phpstan.stub
@@ -1,0 +1,11 @@
+includes:
+    - ./vendor/nunomaduro/larastan/extension.neon
+
+parameters:
+    level: max
+    paths:
+        - app
+        - config
+        - database
+        - routes
+        - tests

--- a/tests/Commands/EssentialsPhpstanCommandTest.php
+++ b/tests/Commands/EssentialsPhpstanCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function (): void {
+    if (file_exists(base_path('phpstan.neon'))) {
+        unlink(base_path('phpstan.neon'));
+    }
+
+    if (file_exists(base_path('phpstan.neon.backup'))) {
+        unlink(base_path('phpstan.neon.backup'));
+    }
+
+    Process::fake([
+        'composer require nunomaduro/larastan --dev' => Process::result(
+            exitCode: 0,
+        ),
+    ]);
+});
+
+it('publishes phpstan configuration file', function (): void {
+    $this->artisan('essentials:phpstan', ['--force' => true])
+        ->assertExitCode(0);
+
+    expect(file_exists(base_path('phpstan.neon')))->toBeTrue();
+
+    $contents = file_get_contents(base_path('phpstan.neon'));
+    expect($contents)->toContain('includes:');
+    expect($contents)->toContain('vendor/nunomaduro/larastan/extension.neon');
+});
+
+it('creates a backup when requested', function (): void {
+    File::put(base_path('phpstan.neon'), 'parameters: []');
+
+    $this->artisan('essentials:phpstan', ['--backup' => true, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(file_exists(base_path('phpstan.neon.backup')))->toBeTrue();
+});
+
+it('warns when file exists and no force option', function (): void {
+    File::put(base_path('phpstan.neon'), 'parameters: []');
+
+    $this->artisan('essentials:phpstan')
+        ->expectsConfirmation('Do you wish to publish the PHPStan configuration file? This will override the existing [phpstan.neon] file.', 'no')
+        ->assertExitCode(0);
+
+    expect(file_get_contents(base_path('phpstan.neon')))->toBe('parameters: []');
+});
+
+it('shows error when larastan installation fails', function (): void {
+    // Fake Laravel Process facade
+    Process::fake([
+        'composer require nunomaduro/larastan --dev' => Process::result(
+            errorOutput: 'Simulated composer error',
+            exitCode: 1,
+        ),
+    ]);
+
+    // Only assert the exit code, skip output assertions
+    $this->artisan('essentials:phpstan', ['--backup' => true, '--force' => true])
+        ->assertExitCode(1);
+});
+
+afterEach(function (): void {
+    if (file_exists(base_path('phpstan.neon'))) {
+        unlink(base_path('phpstan.neon'));
+    }
+
+    if (file_exists(base_path('phpstan.neon.backup'))) {
+        unlink(base_path('phpstan.neon.backup'));
+    }
+});


### PR DESCRIPTION
Thanks for your helpful package.
This PR implements a command like the `essentials:pint` and `essentials:rector` to  publish a `phpstan.neon` config file based on a stub stored in the package.