### PR TITLE
fix: Publish essentials.php config file

### DIFF
--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -61,7 +61,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
 
             $this->publishes([
                 __DIR__.'/../config/essentials.php' => config_path('essentials.php'),
-            ]);
+            ], 'essentials-config');
         }
     }
 }


### PR DESCRIPTION
Adds the necessary configuration to the service provider to publish the essentials.php file to the config directory.