### PR TITLE
feat: implement make:service command and refactor cleanup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All features are optional and configurable in `config/essentials.php`.
 - [Fake Sleep](#-fake-sleep)
 - [Artisan Commands](#-artisan-commands)
   - [make:action](#makeaction)
+  - [make:service](#makeservice)
   - [essentials:pint](#essentialspint)
   - [essentials:rector](#essentialsrector)
 
@@ -155,6 +156,32 @@ final readonly class CreateUserAction
 ```
 
 Actions help organize business logic in dedicated classes, promoting single responsibility and cleaner controllers.
+
+#### `make:service`
+
+Quickly generates service pattern classes in your Laravel application:
+
+```bash
+php artisan make:service UserService
+```
+
+This creates a clean service class at `app/Service/UserService.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+final readonly class UserService
+{
+
+    public function __construct(){}
+
+}
+```
+Service classes are a great way to encapsulate complex business logic that doesn’t belong in controllers or models, helping you keep your codebase modular, testable, and easier to maintain.
 
 #### `essentials:pint`
 

--- a/src/Commands/MakeServiceCommand.php
+++ b/src/Commands/MakeServiceCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+final class MakeServiceCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'make:service';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new service class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Service';
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|int|null
+     */
+    public function handle()
+    {
+        // First check if the class already exists
+        if ($this->alreadyExists($this->getNameInput())) {
+            $this->error($this->type.' already exists!');
+
+            return 1;
+        }
+
+        return parent::handle();
+    }
+
+    /**
+     * Get the name input.
+     */
+    protected function getNameInput(): string
+    {
+        /** @var string $name */
+        $name = $this->argument('name');
+
+        return Str::of(mb_trim($name))
+            ->replaceEnd('.php', '')
+            ->replaceEnd('Service', '')
+            ->append('Service')
+            ->toString();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     */
+    protected function getStub(): string
+    {
+        return $this->resolveStubPath('/stubs/service.stub');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Services';
+    }
+
+    /**
+     * Get the destination class path.
+     */
+    protected function getPath($name): string
+    {
+        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
+
+        // Use the app_path helper to get the correct path
+        return app_path(str_replace('\\', '/', $name).'.php');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     */
+    private function resolveStubPath(string $stub): string
+    {
+        $basePath = $this->laravel->basePath(mb_trim($stub, '/'));
+
+        return file_exists($basePath)
+            ? $basePath
+            : __DIR__.'/../../'.$stub;
+    }
+}

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -40,6 +40,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
         Commands\EssentialsRectorCommand::class,
         Commands\EssentialsPintCommand::class,
         Commands\MakeActionCommand::class,
+        Commands\MakeServiceCommand::class,
     ];
 
     /**

--- a/stubs/service.stub
+++ b/stubs/service.stub
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+final readonly class {{ class }}
+{
+
+    public function __construct(){}
+
+}

--- a/tests/Commands/MakeActionCommandTest.php
+++ b/tests/Commands/MakeActionCommandTest.php
@@ -5,23 +5,6 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 
-function cleanup(): void
-{
-    $actionsPath = app_path('Actions');
-
-    if (File::isDirectory($actionsPath)) {
-        File::deleteDirectory($actionsPath);
-    }
-
-    $stubsPath = base_path('stubs');
-    if (File::exists($stubsPath)) {
-        File::deleteDirectory($stubsPath);
-    }
-}
-
-beforeEach(fn () => cleanup());
-afterEach(fn () => cleanup());
-
 it('creates a new action file', function (): void {
     $actionName = 'CreateUserAction';
     $exitCode = Artisan::call('make:action', ['name' => $actionName]);

--- a/tests/Commands/MakeServiceCommandTest.php
+++ b/tests/Commands/MakeServiceCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+it('creates a new service file', function (): void {
+    $serviceName = 'UserService';
+    $exitCode = Artisan::call('make:service', ['name' => $serviceName]);
+
+    expect($exitCode)->toBe(0);
+
+    $expectedPath = app_path('Services/'.$serviceName.'.php');
+    expect(File::exists($expectedPath))->toBeTrue();
+
+    $content = File::get($expectedPath);
+
+    expect($content)
+        ->toContain('namespace App\Services;')
+        ->toContain('class '.$serviceName)
+        ->toContain('public function __construct(){}');
+});
+
+it('fails when the service already exists', function (): void {
+    $serviceName = 'UserService';
+    Artisan::call('make:service', ['name' => $serviceName]);
+    $exitCode = Artisan::call('make:service', ['name' => $serviceName]);
+
+    expect($exitCode)->toBe(1);
+});
+
+it('add suffix "Service" to service name if not provided', function (string $serviceName): void {
+    $exitCode = Artisan::call('make:service', ['name' => $serviceName]);
+
+    expect($exitCode)->toBe(0);
+
+    $expectedPath = app_path('Services/UserService.php');
+    expect(File::exists($expectedPath))->toBeTrue();
+
+    $content = File::get($expectedPath);
+
+    expect($content)
+        ->toContain('namespace App\Services;')
+        ->toContain('class UserService')
+        ->toContain('public function __construct(){}');
+})->with([
+    'UserService',
+    'UserService.php',
+]);
+
+it('uses published stub when available', function (): void {
+    $this->artisan('vendor:publish', ['--tag' => 'essentials-stubs'])
+        ->assertSuccessful();
+
+    $publishedStubPath = base_path('stubs/service.stub');
+    $originalContent = File::get($publishedStubPath);
+    File::put($publishedStubPath, $originalContent."\n// this is user modified stub");
+
+    $serviceName = 'TestPublishedStubService';
+    $this->artisan('make:service', ['name' => $serviceName])
+        ->assertSuccessful();
+
+    $expectedPath = app_path('Services/TestPublishedStubService.php');
+    expect(File::exists($expectedPath))->toBeTrue()
+        ->and(File::get($expectedPath))->toContain(
+            '// this is user modified stub'
+        );
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,4 +4,29 @@ declare(strict_types=1);
 
 use Tests\TestCase;
 
-pest()->use(TestCase::class);
+pest()->use(TestCase::class)
+    ->in('Configurables');
+
+pest()->use(TestCase::class)
+    ->in('Commands')
+    ->beforeEach(fn () => cleanup())
+    ->afterEach(fn () => cleanup());
+
+function cleanup(): void
+{
+    $makeCommandPaths = [
+        app_path('Actions'),
+        app_path('Services'),
+    ];
+
+    foreach ($makeCommandPaths as $path) {
+        if (File::isDirectory($path)) {
+            File::deleteDirectory($path);
+        }
+    }
+
+    $stubsPath = base_path('stubs');
+    if (File::exists($stubsPath)) {
+        File::deleteDirectory($stubsPath);
+    }
+}


### PR DESCRIPTION
### Why?
Some developers use the Service pattern in Laravel, so having a make command with a customizable stub would make it easier to generate services consistently and therefore save time if you want to use it.

----

### Adding the `make:service` command with according stub.

_example service_
```php
<?php

declare(strict_types=1);

namespace App\Services;

final readonly class UserService
{

    public function __construct(){}

}

```

### refactor part:
For the second `make:anything` command I also reworked the `cleanup()` handling in `Pest.php`
