### PR TITLE
chore: 100% test coverage

### DIFF
--- a/src/Commands/EssentialsPintCommand.php
+++ b/src/Commands/EssentialsPintCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Essentials\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
 
 final class EssentialsPintCommand extends Command
 {
@@ -36,20 +37,20 @@ final class EssentialsPintCommand extends Command
         $stub_path = __DIR__.'/../../stubs/pint.stub';
         $destination_path = base_path('pint.json');
 
-        if (! file_exists($stub_path)) {
+        if (! File::exists($stub_path)) {
             $this->components->error('Pint configuration stub file not found.');
 
             return 1;
         }
 
-        if (file_exists($destination_path) && $this->option('backup')) {
-            copy($destination_path, $destination_path.'.backup');
+        if (File::exists($destination_path) && $this->option('backup')) {
+            File::copy($destination_path, $destination_path.'.backup');
             $this->components->info('Backup created at: '.$destination_path.'.backup');
         }
 
         $this->components->info('Publishing Pint configuration file...');
 
-        if (! copy($stub_path, $destination_path)) {
+        if (! File::copy($stub_path, $destination_path)) {
             $this->components->error('Failed to publish the Pint configuration file.');
 
             return 1;

--- a/src/Commands/EssentialsRectorCommand.php
+++ b/src/Commands/EssentialsRectorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Essentials\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
 
 final class EssentialsRectorCommand extends Command
 {
@@ -36,20 +37,20 @@ final class EssentialsRectorCommand extends Command
         $stub_path = __DIR__.'/../../stubs/rector.stub';
         $destination_path = base_path('rector.php');
 
-        if (! file_exists($stub_path)) {
+        if (! File::exists($stub_path)) {
             $this->components->error('Rector configuration stub file not found.');
 
             return 1;
         }
 
-        if (file_exists($destination_path) && $this->option('backup')) {
-            copy($destination_path, $destination_path.'.backup');
+        if (File::exists($destination_path) && $this->option('backup')) {
+            File::copy($destination_path, $destination_path.'.backup');
             $this->components->info('Backup created at: '.$destination_path.'.backup');
         }
 
         $this->components->info('Publishing Rector configuration file...');
 
-        if (! copy($stub_path, $destination_path)) {
+        if (! File::copy($stub_path, $destination_path)) {
             $this->components->error('Failed to publish the Rector configuration file.');
 
             return 1;

--- a/tests/Commands/EssentialsPintCommandTest.php
+++ b/tests/Commands/EssentialsPintCommandTest.php
@@ -15,11 +15,12 @@ beforeEach(function (): void {
     }
 });
 
-it('publishes pint configuration file', function (): void {
+it('publishes pint configuration file without a backup by default', function (): void {
     $this->artisan('essentials:pint', ['--force' => true])
         ->assertExitCode(0);
 
     expect(file_exists(base_path('pint.json')))->toBeTrue();
+    expect(file_exists(base_path('pint.json.backup')))->toBeFalse();
 });
 
 it('returns error when pint configuration file does not exist', function (): void {

--- a/tests/Commands/EssentialsPintCommandTest.php
+++ b/tests/Commands/EssentialsPintCommandTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\File;
-use NunoMaduro\Essentials\Commands\EssentialsPintCommand;
 
 beforeEach(function (): void {
     // Clean up any existing pint.json files
@@ -17,8 +16,6 @@ beforeEach(function (): void {
 });
 
 it('publishes pint configuration file', function (): void {
-    $command = new EssentialsPintCommand;
-
     $this->artisan('essentials:pint', ['--force' => true])
         ->assertExitCode(0);
 

--- a/tests/Commands/EssentialsRectorCommandTest.php
+++ b/tests/Commands/EssentialsRectorCommandTest.php
@@ -21,6 +21,26 @@ it('publishes rector configuration file', function (): void {
     expect(file_exists(base_path('rector.php')))->toBeTrue();
 });
 
+it('returns error when rector configuration file does not exist', function (): void {
+    File::shouldReceive('exists')
+        ->once()
+        ->andReturnFalse();
+
+    $this->artisan('essentials:rector', ['--force' => true])
+        ->expectsOutputToContain('Rector configuration stub file not found.')
+        ->assertExitCode(1);
+});
+
+it('returns error when copy operation fails', function (): void {
+    File::shouldReceive('exists')->andReturnTrue();
+    File::shouldReceive('copy')
+        ->once()
+        ->andReturnFalse();
+
+    $this->artisan('essentials:rector', ['--force' => true])
+        ->assertExitCode(1);
+});
+
 it('creates a backup when requested', function (): void {
     File::put(base_path('rector.php'), '<?php return [];');
 
@@ -38,6 +58,18 @@ it('warns when file exists and no force option', function (): void {
         ->assertExitCode(0);
 
     expect(file_get_contents(base_path('rector.php')))->toBe('<?php return [];');
+});
+
+it('publishes rector configuration file when user confirms', function (): void {
+    File::put(base_path('rector.php'), '<?php return [];');
+
+    $this->artisan('essentials:rector')
+        ->expectsConfirmation('Do you wish to publish the Rector configuration file? This will override the existing [rector.php] file.', 'yes')
+        ->assertExitCode(0);
+
+    expect(file_get_contents(base_path('rector.php')))
+        ->not()
+        ->toBe('<?php return [];');
 });
 
 afterEach(function (): void {

--- a/tests/Commands/EssentialsRectorCommandTest.php
+++ b/tests/Commands/EssentialsRectorCommandTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\File;
-use NunoMaduro\Essentials\Commands\EssentialsRectorCommand;
 
 beforeEach(function (): void {
     if (file_exists(base_path('rector.php'))) {
@@ -16,8 +15,6 @@ beforeEach(function (): void {
 });
 
 it('publishes rector configuration file', function (): void {
-    $command = new EssentialsRectorCommand();
-
     $this->artisan('essentials:rector', ['--force' => true])
         ->assertExitCode(0);
 

--- a/tests/Commands/EssentialsRectorCommandTest.php
+++ b/tests/Commands/EssentialsRectorCommandTest.php
@@ -14,11 +14,12 @@ beforeEach(function (): void {
     }
 });
 
-it('publishes rector configuration file', function (): void {
+it('publishes rector configuration file without a backup by default', function (): void {
     $this->artisan('essentials:rector', ['--force' => true])
         ->assertExitCode(0);
 
     expect(file_exists(base_path('rector.php')))->toBeTrue();
+    expect(file_exists(base_path('rector.json.backup')))->toBeFalse();
 });
 
 it('returns error when rector configuration file does not exist', function (): void {


### PR DESCRIPTION
I replaced the native PHP functions `file_exists` and `copy` with the Laravel File Facade alternatives ([which are wrappers for the original functions](https://laravel.com/docs/12.x/facades)) to increase command testability. From there, I was able to add the missing tests to achieve 100% test coverage.

Missing test cases for Pint and Rector commands:

1. If the pint or rector configuration files do not exist for any reason, the commands should fail.
2. If the user confirms that they want to overwrite the existing pint or rector configuration files, the files should be overwritten.
3. If for any reason we can't copy the pint or rector configuration files, the commands should fail.

I also modified an existing test case to explicitly test that backups of configuration files are not created without passing the `--backup` option.