### PR TITLE
fix: Publish config file

### DIFF
--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -61,7 +61,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
 
             $this->publishes([
                 __DIR__.'/../config/essentials.php' => config_path('essentials.php'),
-            ]);
+            ], 'essentials-config');
         }
     }
 }


### PR DESCRIPTION
This PR fixes the publish config command:

```
php artisan vendor:publish --tag=essentials-config
```