### PR TITLE
Place `casts` method at the top

### DIFF
--- a/stubs/pint.stub
+++ b/stubs/pint.stub
@@ -40,6 +40,7 @@
                 "destruct",
                 "magic",
                 "phpunit",
+                "method:casts",
                 "method_abstract",
                 "method_public_static",
                 "method_public",


### PR DESCRIPTION
The `casts` method is moved to the top of the model to match the common convention. Previously, the `$casts` property was always placed at the top, so this keeps the same order.
