### PR TITLE
Enhance password defaults for production environment

### DIFF
--- a/src/Configurables/SetDefaultPassword.php
+++ b/src/Configurables/SetDefaultPassword.php
@@ -22,6 +22,6 @@ final class SetDefaultPassword implements Configurable
      */
     public function configure(): void
     {
-        Password::defaults(fn (): ?Password => app()->isProduction() ? Password::min(12)->max(255)->uncompromised() : null);
+        Password::defaults(fn (): ?Password => app()->isProduction() ? Password::min(12)->letters()->mixedCase()->numbers()->symbols()->max(255)->uncompromised() : null);
     }
 }


### PR DESCRIPTION
## Strengthen Password Defaults

According to [security.org](https://www.security.org/how-secure-is-my-password/) benchmarks, 12-character, single-case, letter-only passwords can be brute-forced in ~3 weeks, which is insufficient for production security.

### Changes
- Require **mixed case, numbers, and symbols**

### Impact
- Applies to **new passwords only**
- Existing passwords remain valid

### Proposal
This PR improves baseline security with no breaking changes and is proposed to be **merged**.
