### PR TITLE
Make commands optional

### DIFF
--- a/config/essentials.php
+++ b/config/essentials.php
@@ -173,8 +173,8 @@ return [
     | Enabled commands
     |--------------------------------------------------------------------------
     | This option allows you to specify which commands should be
-    | registered in your application. You can add or remove commands
-    | as needed.
+    | registered in your application. You can remove commands
+    | if needed.
     |
     */
 

--- a/config/essentials.php
+++ b/config/essentials.php
@@ -168,4 +168,19 @@ return [
 
     NunoMaduro\Essentials\Configurables\Unguard::class => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Enabled commands
+    |--------------------------------------------------------------------------
+    | This option allows you to specify which commands should be
+    | registered in your application. You can add or remove commands
+    | as needed.
+    |
+    */
+
+    'commands' => [
+        NunoMaduro\Essentials\Commands\EssentialsRectorCommand::class,
+        NunoMaduro\Essentials\Commands\EssentialsPintCommand::class,
+        NunoMaduro\Essentials\Commands\MakeActionCommand::class,
+    ],
 ];

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -32,11 +32,11 @@ final class EssentialsServiceProvider extends BaseServiceProvider
     ];
 
     /**
-     * The list of commands.
+     * The default list of commands.
      *
      * @var list<class-string<Command>>
      */
-    private array $commandsList = [
+    private array $defaultCommandsList = [
         Commands\EssentialsRectorCommand::class,
         Commands\EssentialsPintCommand::class,
         Commands\MakeActionCommand::class,
@@ -53,7 +53,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
             ->each(fn (Configurable $configurable) => $configurable->configure());
 
         if ($this->app->runningInConsole()) {
-            $this->commands($this->commandsList);
+            $this->commands(config('essentials.commands', $this->defaultCommandsList));
 
             $this->publishes([
                 __DIR__.'/../stubs' => $this->app->basePath('stubs'),

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Essentials;
 
-use Illuminate\Console\Command;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use NunoMaduro\Essentials\Contracts\Configurable;
 


### PR DESCRIPTION
I wanted to use this package but also the package [lorisleiva/laravel-actions](https://github.com/lorisleiva/laravel-actions).

Since both packages have the `make:action` command i wanted to make this pull request to make the commands optional. 

Let me know what you think and if you want me to add tests or something in the README.

Thanks!