### PR TITLE
Add `FailOnUnknownFields` configurable to Essentials

### DIFF
--- a/config/essentials.php
+++ b/config/essentials.php
@@ -37,6 +37,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fail On Unknown Fields
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to fail on unknown fields in form requests.
+    | When enabled, the framework will throw a validation error if
+    | the request contains fields that are not defined in the
+    | form request rules.
+    |
+    | Enabled by default.
+    |
+    | Note: This option is only available in Laravel 13.4 and above.
+    |
+    */
+
+    NunoMaduro\Essentials\Configurables\FailOnUnknownFields::class => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Fake Sleep when running tests
     |--------------------------------------------------------------------------
     |

--- a/config/essentials.php
+++ b/config/essentials.php
@@ -45,13 +45,13 @@ return [
     | the request contains fields that are not defined in the
     | form request rules.
     |
-    | Enabled by default.
+    | Disabled by default.
     |
     | Note: This option is only available in Laravel 13.4 and above.
     |
     */
 
-    NunoMaduro\Essentials\Configurables\FailOnUnknownFields::class => true,
+    NunoMaduro\Essentials\Configurables\FailOnUnknownFields::class => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Configurables/FailOnUnknownFields.php
+++ b/src/Configurables/FailOnUnknownFields.php
@@ -22,7 +22,7 @@ final readonly class FailOnUnknownFields implements Configurable
      */
     public function configure(): void
     {
-        if (! method_exists(FormRequest::class, 'failOnUnknownFields')) {
+        if (! method_exists(FormRequest::class, 'failOnUnknownFields')) { // @phpstan-ignore function.alreadyNarrowedType
             return;
         }
 

--- a/src/Configurables/FailOnUnknownFields.php
+++ b/src/Configurables/FailOnUnknownFields.php
@@ -22,6 +22,10 @@ final readonly class FailOnUnknownFields implements Configurable
      */
     public function configure(): void
     {
+        if (! method_exists(FormRequest::class, 'failOnUnknownFields')) {
+            return;
+        }
+
         FormRequest::failOnUnknownFields();
     }
 }

--- a/src/Configurables/FailOnUnknownFields.php
+++ b/src/Configurables/FailOnUnknownFields.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Configurables;
+
+use Illuminate\Foundation\Http\FormRequest;
+use NunoMaduro\Essentials\Contracts\Configurable;
+
+final readonly class FailOnUnknownFields implements Configurable
+{
+    /**
+     * Whether the configurable is enabled or not.
+     */
+    public function enabled(): bool
+    {
+        return config()->boolean(sprintf('essentials.%s', self::class), true);
+    }
+
+    /**
+     * Run the configurable.
+     */
+    public function configure(): void
+    {
+        FormRequest::failOnUnknownFields();
+    }
+}

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -21,6 +21,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
     private array $configurables = [
         Configurables\AggressivePrefetching::class,
         Configurables\AutomaticallyEagerLoadRelationships::class,
+        Configurables\FailOnUnknownFields::class,
         Configurables\FakeSleep::class,
         Configurables\ForceScheme::class,
         Configurables\ImmutableDates::class,

--- a/tests/Configurables/FailOnUnknownFieldsTest.php
+++ b/tests/Configurables/FailOnUnknownFieldsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Http\FormRequest;
+use NunoMaduro\Essentials\Configurables\FailOnUnknownFields;
+
+beforeEach(function (): void {
+    FormRequest::failOnUnknownFields(false);
+});
+
+it('enables fail on unknown fields for form requests', function (): void {
+    $failOnUnknownFields = new FailOnUnknownFields;
+    $failOnUnknownFields->configure();
+
+    $reflection = new ReflectionClass(FormRequest::class);
+    $property = $reflection->getProperty('globalFailOnUnknownFields');
+
+    expect($property->getValue())->toBeTrue();
+});
+
+it('is enabled by default', function (): void {
+    $failOnUnknownFields = new FailOnUnknownFields;
+
+    expect($failOnUnknownFields->enabled())->toBeTrue();
+});
+
+it('can be disabled via configuration', function (): void {
+    config()->set('essentials.'.FailOnUnknownFields::class, false);
+
+    $failOnUnknownFields = new FailOnUnknownFields;
+
+    expect($failOnUnknownFields->enabled())->toBeFalse();
+});

--- a/tests/Configurables/FailOnUnknownFieldsTest.php
+++ b/tests/Configurables/FailOnUnknownFieldsTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 use Illuminate\Foundation\Http\FormRequest;
 use NunoMaduro\Essentials\Configurables\FailOnUnknownFields;
 
-beforeEach(function (): void {
-    FormRequest::failOnUnknownFields(false);
-});
-
 it('enables fail on unknown fields for form requests', function (): void {
     $failOnUnknownFields = new FailOnUnknownFields;
     $failOnUnknownFields->configure();
@@ -17,7 +13,10 @@ it('enables fail on unknown fields for form requests', function (): void {
     $property = $reflection->getProperty('globalFailOnUnknownFields');
 
     expect($property->getValue())->toBeTrue();
-});
+})->skip(
+    fn (): bool => ! method_exists(FormRequest::class, 'failOnUnknownFields'),
+    'failOnUnknownFields is not supported in this version of Laravel.'
+);
 
 it('is enabled by default', function (): void {
     $failOnUnknownFields = new FailOnUnknownFields;
@@ -32,3 +31,13 @@ it('can be disabled via configuration', function (): void {
 
     expect($failOnUnknownFields->enabled())->toBeFalse();
 });
+
+it('does nothing when failOnUnknownFields method does not exist', function (): void {
+    $failOnUnknownFields = new FailOnUnknownFields;
+    $failOnUnknownFields->configure();
+
+    expect($failOnUnknownFields->enabled())->toBeTrue();
+})->skip(
+    fn (): bool => method_exists(FormRequest::class, 'failOnUnknownFields'),
+    'failOnUnknownFields exists in this version of Laravel.'
+);


### PR DESCRIPTION
Introduced a new configurable that triggers validation errors for unknown fields in form requests. Disabled by default and compatible with Laravel 13.4+. Includes tests and configuration updates.