### PR TITLE
fix: stop appending Action suffix in make:action

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ Configures Laravel Sleep Facade to be faked.
 Quickly generates action classes in your Laravel application:
 
 ```bash
-php artisan make:action CreateUserAction
+php artisan make:action CreateUser
 ```
 
-This creates a clean action class at `app/Actions/CreateUserAction.php`:
+This creates a clean action class at `app/Actions/CreateUser.php`:
 
 ```php
 <?php
@@ -147,7 +147,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-final readonly class CreateUserAction
+final readonly class CreateUser
 {
     /**
      * Execute the action.
@@ -160,6 +160,8 @@ final readonly class CreateUserAction
     }
 }
 ```
+
+Actions already live under `app/Actions`, so the class name does not need an `Action` suffix. The command uses the given name as-is (only stripping a trailing `.php` if present).
 
 Actions help organize business logic in dedicated classes, promoting single responsibility and cleaner controllers.
 

--- a/src/Commands/MakeActionCommand.php
+++ b/src/Commands/MakeActionCommand.php
@@ -57,8 +57,6 @@ final class MakeActionCommand extends GeneratorCommand
 
         return Str::of(mb_trim($name))
             ->replaceEnd('.php', '')
-            ->replaceEnd('Action', '')
-            ->append('Action')
             ->toString();
     }
 

--- a/tests/Commands/MakeActionCommandTest.php
+++ b/tests/Commands/MakeActionCommandTest.php
@@ -23,7 +23,7 @@ beforeEach(fn () => cleanup());
 afterEach(fn () => cleanup());
 
 it('creates a new action file', function (): void {
-    $actionName = 'CreateUserAction';
+    $actionName = 'CreateUser';
     $exitCode = Artisan::call('make:action', ['name' => $actionName]);
 
     expect($exitCode)->toBe(0);
@@ -40,31 +40,44 @@ it('creates a new action file', function (): void {
 });
 
 it('fails when the action already exists', function (): void {
-    $actionName = 'CreateUserAction';
+    $actionName = 'CreateUser';
     Artisan::call('make:action', ['name' => $actionName]);
     $exitCode = Artisan::call('make:action', ['name' => $actionName]);
 
     expect($exitCode)->toBe(1);
 });
 
-it('add suffix "Action" to action name if not provided', function (string $actionName): void {
+it('does not append an Action suffix', function (string $actionName): void {
     $exitCode = Artisan::call('make:action', ['name' => $actionName]);
+
+    expect($exitCode)->toBe(0);
+
+    $expectedPath = app_path('Actions/CreateUser.php');
+    expect(File::exists($expectedPath))->toBeTrue();
+    expect(File::exists(app_path('Actions/CreateUserAction.php')))->toBeFalse();
+
+    $content = File::get($expectedPath);
+
+    expect($content)
+        ->toContain('namespace App\Actions;')
+        ->toContain('class CreateUser')
+        ->toContain('public function handle(): void');
+})->with([
+    'CreateUser',
+    'CreateUser.php',
+]);
+
+it('uses the name as provided when it already ends with Action', function (): void {
+    $exitCode = Artisan::call('make:action', ['name' => 'CreateUserAction']);
 
     expect($exitCode)->toBe(0);
 
     $expectedPath = app_path('Actions/CreateUserAction.php');
     expect(File::exists($expectedPath))->toBeTrue();
 
-    $content = File::get($expectedPath);
-
-    expect($content)
-        ->toContain('namespace App\Actions;')
-        ->toContain('class CreateUserAction')
-        ->toContain('public function handle(): void');
-})->with([
-    'CreateUser',
-    'CreateUser.php',
-]);
+    expect(File::get($expectedPath))
+        ->toContain('class CreateUserAction');
+});
 
 it('uses published stub when available', function (): void {
     $this->artisan('vendor:publish', ['--tag' => 'essentials-stubs'])
@@ -74,11 +87,11 @@ it('uses published stub when available', function (): void {
     $originalContent = File::get($publishedStubPath);
     File::put($publishedStubPath, $originalContent."\n// this is user modified stub");
 
-    $actionName = 'TestPublishedStubAction';
+    $actionName = 'TestPublishedStub';
     $this->artisan('make:action', ['name' => $actionName])
         ->assertSuccessful();
 
-    $expectedPath = app_path('Actions/TestPublishedStubAction.php');
+    $expectedPath = app_path('Actions/TestPublishedStub.php');
     expect(File::exists($expectedPath))->toBeTrue()
         ->and(File::get($expectedPath))->toContain(
             '// this is user modified stub'


### PR DESCRIPTION
## Summary

- Action classes already live under `app/Actions` / `App\Actions`, so appending an `Action` class-name suffix is redundant (similar to `UserModel` inside `Models`).
- `make:action` now uses the given name as-is, only stripping a trailing `.php` if present.
- README examples updated to `CreateUser` instead of `CreateUserAction`.

This also aligns with the suffix-free convention in [laravel-starter-kit-inertia-react](https://github.com/nunomaduro/laravel-starter-kit-inertia-react) (`CreateUser`, `DeleteUser`, Boost guideline example `CreateFavorite`).

**Note:** This is a breaking change for anyone relying on the auto-appended `Action` suffix.

## Test plan

- [x] `composer lint`
- [x] `composer test:unit` (100% coverage, including `MakeActionCommand`)
- [ ] Confirm `php artisan make:action CreateUser` creates `app/Actions/CreateUser.php`
- [ ] Confirm `php artisan make:action CreateUser.php` still works
- [ ] Confirm an explicit `CreateUserAction` name is still respected as provided