### PR TITLE
feat(commands): add make query command

### DIFF
--- a/src/Commands/MakeQueryCommand.php
+++ b/src/Commands/MakeQueryCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Essentials\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+final class MakeQueryCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'make:query';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new query class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Query';
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|int|null
+     */
+    public function handle()
+    {
+        // First check if the class already exists
+        if ($this->alreadyExists($this->getNameInput())) {
+            $this->error($this->type.' already exists!');
+
+            return 1;
+        }
+
+        return parent::handle();
+    }
+
+    /**
+     * Get the name input.
+     */
+    protected function getNameInput(): string
+    {
+        /** @var string $name */
+        $name = $this->argument('name');
+
+        return Str::of(mb_trim($name))
+            ->replaceEnd('.php', '')
+            ->replaceEnd('Query', '')
+            ->append('Query')
+            ->toString();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     */
+    protected function getStub(): string
+    {
+        return $this->resolveStubPath('/stubs/query.stub');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Queries';
+    }
+
+    /**
+     * Get the destination class path.
+     */
+    protected function getPath($name): string
+    {
+        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
+
+        // Use the app_path helper to get the correct path
+        return app_path(str_replace('\\', '/', $name).'.php');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     */
+    private function resolveStubPath(string $stub): string
+    {
+        $basePath = $this->laravel->basePath(mb_trim($stub, '/'));
+
+        return file_exists($basePath)
+            ? $basePath
+            : __DIR__.'/../../'.$stub;
+    }
+}

--- a/src/EssentialsServiceProvider.php
+++ b/src/EssentialsServiceProvider.php
@@ -40,6 +40,7 @@ final class EssentialsServiceProvider extends BaseServiceProvider
         Commands\EssentialsRectorCommand::class,
         Commands\EssentialsPintCommand::class,
         Commands\MakeActionCommand::class,
+        Commands\MakeQueryCommand::class,
     ];
 
     /**

--- a/stubs/query.stub
+++ b/stubs/query.stub
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Facades\DB;
+
+final readonly class {{ class }}
+{
+    /**
+     * Handle query
+     */
+    public function get(): void
+    {
+        
+    }
+}

--- a/tests/Commands/MakeActionCommandTest.php
+++ b/tests/Commands/MakeActionCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 
-function cleanup(): void
+function cleanupMakeAction(): void
 {
     $actionsPath = app_path('Actions');
 
@@ -19,8 +19,8 @@ function cleanup(): void
     }
 }
 
-beforeEach(fn () => cleanup());
-afterEach(fn () => cleanup());
+beforeEach(fn () => cleanupMakeAction());
+afterEach(fn () => cleanupMakeAction());
 
 it('creates a new action file', function (): void {
     $actionName = 'CreateUserAction';

--- a/tests/Commands/MakeQueryCommandTest.php
+++ b/tests/Commands/MakeQueryCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+function cleanupMakeQuery(): void
+{
+    $queriesPath = app_path('Queries');
+
+    if (File::isDirectory($queriesPath)) {
+        File::deleteDirectory($queriesPath);
+    }
+
+    $stubsPath = base_path('stubs');
+    if (File::exists($stubsPath)) {
+        File::deleteDirectory($stubsPath);
+    }
+}
+
+beforeEach(fn () => cleanupMakeQuery());
+afterEach(fn () => cleanupMakeQuery());
+
+it('creates a new query file', function (): void {
+    $queryName = 'GetUsersQuery';
+    $exitCode = Artisan::call('make:query', ['name' => $queryName]);
+
+    expect($exitCode)->toBe(0);
+
+    $expectedPath = app_path('Queries/'.$queryName.'.php');
+    expect(File::exists($expectedPath))->toBeTrue();
+
+    $content = File::get($expectedPath);
+
+    expect($content)
+        ->toContain('namespace App\Queries;')
+        ->toContain('class '.$queryName)
+        ->toContain('public function get(): void');
+});
+
+it('fails when the query already exists', function (): void {
+    $queryName = 'GetUsersQuery';
+    Artisan::call('make:query', ['name' => $queryName]);
+    $exitCode = Artisan::call('make:query', ['name' => $queryName]);
+
+    expect($exitCode)->toBe(1);
+});
+
+it('add suffix "Query" to query name if not provided', function (string $queryName): void {
+    $exitCode = Artisan::call('make:query', ['name' => $queryName]);
+
+    expect($exitCode)->toBe(0);
+
+    $expectedPath = app_path('Queries/GetUsersQuery.php');
+    expect(File::exists($expectedPath))->toBeTrue();
+
+    $content = File::get($expectedPath);
+
+    expect($content)
+        ->toContain('namespace App\Queries;')
+        ->toContain('class GetUsersQuery')
+        ->toContain('public function get(): void');
+})->with([
+    'GetUsers',
+    'GetUsers.php',
+]);
+
+it('uses published stub when available', function (): void {
+    $this->artisan('vendor:publish', ['--tag' => 'essentials-stubs'])
+        ->assertSuccessful();
+
+    $publishedStubPath = base_path('stubs/query.stub');
+    $originalContent = File::get($publishedStubPath);
+    File::put($publishedStubPath, $originalContent."\n// this is user modified stub");
+
+    $queryName = 'TestPublishedStubQuery';
+    $this->artisan('make:query', ['name' => $queryName])
+        ->assertSuccessful();
+
+    $expectedPath = app_path('Queries/TestPublishedStubQuery.php');
+    expect(File::exists($expectedPath))->toBeTrue()
+        ->and(File::get($expectedPath))->toContain(
+            '// this is user modified stub'
+        );
+});


### PR DESCRIPTION
### Feature: Add make:query Artisan command

#### Description:
This pull request introduces the make:query Artisan command, providing a convenient and standardized way to generate Query classes within the application. This encourages a cleaner architecture by helping developers easily separate database query logic from controllers.


#### Key Features & Behaviors:
- Automatic Suffixing: Automatically appends the Query suffix to the generated class name if it is omitted by the user. For instance, running `php artisan make:query GetUsers` will intelligently generate GetUsersQuery.php.
- Default Namespace & Path: The generated query classes are placed in the App\Queries directory by default.
- Modern PHP Scaffolding: Uses a stub to scaffold a final readonly class containing a default get(): void method, promoting modern and strict PHP practices. 
- Customizable Stubs: Fully supports stub customization. Developers can publish the stub using `php artisan vendor:publish --tag=essentials-stubs` and modify stubs/query.stub to fit their specific needs.
- Conflict Prevention: Safely aborts and returns an error if the specified Query class already exists, preventing accidental overwrites.
- Test Coverage: Includes comprehensive unit tests ensuring the command behaves exactly as expected in all scenarios.